### PR TITLE
Update redis.py to resolve issue with duplicate base class TimeoutErr…

### DIFF
--- a/aio_pubsub/backends/redis.py
+++ b/aio_pubsub/backends/redis.py
@@ -29,7 +29,7 @@ class RedisSubscriber(Subscriber):
                     if message is not None:
                         return message["data"]
                     await asyncio.sleep(0.01)
-            except asyncio.TimeoutError:
+            except (asyncio.TimeoutError, async_timeout.TimeoutError):
                 pass
 
 


### PR DESCRIPTION
…or in python 3.11